### PR TITLE
Updated SleepWaitMenu to be compatible with Modern Wait Menu

### DIFF
--- a/src/Menus/SleepWaitMenuEx.cpp
+++ b/src/Menus/SleepWaitMenuEx.cpp
@@ -32,13 +32,9 @@ namespace SkyrimSoulsRE
 		char timeDateString[200];
 		RE::Calendar::GetSingleton()->GetTimeDateString(timeDateString, 200, false);
 
-		RE::GFxValue dateText;
-		this->uiMovie->GetVariable(&dateText, "_root.SleepWaitMenu_mc.CurrentTime");
-		if (dateText.GetType() != RE::GFxValue::ValueType::kUndefined)
-		{
-			RE::GFxValue newDate(timeDateString);
-			dateText.SetMember("htmlText", newDate);
-		}
+		RE::GFxValue args[1];
+		args[0].SetString(timeDateString);
+		this->uiMovie->Invoke("_root.SleepWaitMenu_mc.SetCurrentTime", nullptr, args, 1);
 	}
 
 	void SleepWaitMenuEx::StartSleepWait_Hook(const RE::FxDelegateArgs& a_args)


### PR DESCRIPTION
The [Modern Wait Menu](https://www.nexusmods.com/skyrimspecialedition/mods/117661) mod relies on overriding the SetCurrentTime function to add some additional formatting logic for its display. SkyrimSoulsRE currently bypasses this logic completely by setting the CurrentTime variable value directly instead of calling the vanilla function. This PR intends to remediate this issue.

See the following picture to see how the text currently clips:
https://ibb.co/WvcMCVm